### PR TITLE
docs: update Shopify CLI links and remove Stylelint from features

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,19 @@ Please refer to [shopify-quick-theme-mix](https://github.com/Kazuki-tam/shopify-
 - Bundle TS files with Rspack
 - Transpile SCSS to CSS
 - Lint TS files with Biome
-- Lint SCSS files with Stylelint
 - Built-in test runner with Vitest and Playwright
 
 ## Requirements
 
 - [Node v22 or higher](https://nodejs.org/en/)
-- [Shopify CLI v3.78.2 or higher](https://shopify.dev/themes/tools/cli)
+- [Shopify CLI v3.78.2 or higher](https://shopify.dev/docs/api/shopify-cli/theme)
 
-Note: Please refer to [Install Shopify CLI](https://shopify.dev/themes/tools/cli/installation) if you haven't installed Shopify CLI yet.
+Note: Please refer to [Install Shopify CLI](https://shopify.dev/docs/api/shopify-cli) if you haven't installed Shopify CLI yet.
 
-[📖 Upgrade or uninstall Shopify CLI](https://shopify.dev/themes/tools/cli/upgrade-uninstall)
+[📖 Upgrade or uninstall Shopify CLI](https://shopify.dev/docs/storefronts/themes/tools/cli#upgrade-shopify-cli)
 ## Main dependencies
 
-- [Shopify CLI](https://shopify.dev/themes/tools/cli)
+- [Shopify CLI](https://shopify.dev/docs/api/shopify-cli/theme)
 - [pnpm](https://pnpm.io/)
 - [Rspack](https://www.rspack.dev/)
 - [TypeScript](https://www.typescriptlang.org/)


### PR DESCRIPTION
This pull request updates the `README.md` file to fix outdated Shopify CLI links and remove Stylelint as a listed dependency for SCSS linting.

### Documentation updates:

* Updated Shopify CLI links to point to the latest documentation URLs.
* Adjusted the note and upgrade/uninstall links for Shopify CLI to reflect the new documentation structure.

### Dependency updates:

* Removed Stylelint as a listed tool for SCSS linting, indicating it is no longer part of the setup.